### PR TITLE
WIP: Sichere Token generieren

### DIFF
--- a/plugins/client/install.php
+++ b/plugins/client/install.php
@@ -1,5 +1,5 @@
 <?php
 
 if (!$this->hasConfig()) {
-    $this->setConfig('project_manager_api_key', md5(time()));
+    $this->setConfig('project_manager_api_key', bin2hex(random_bytes(24)));
 }    

--- a/plugins/client/pages/project_manager.client.page.php
+++ b/plugins/client/pages/project_manager.client.page.php
@@ -16,7 +16,7 @@ $formElements = [];
 $n = [];
 $n['label'] = '<label for="phpmailer-project_manager_api_key">' . $this->i18n('project_manager_api_key_label') . '</label>';
 $n['field'] = '<input class="form-control" id="" name="settings[project_manager_api_key]" value="'.$this->getConfig('project_manager_api_key') . '" />';
-$n['note'] = $this->i18n('project_manager_api_key_notice').' <code>'.md5(time()).'</code>';
+$n['note'] = $this->i18n('project_manager_api_key_notice').' <code>'.bin2hex(random_bytes(24)).'</code>';
 
 $formElements[] = $n;
 


### PR DESCRIPTION
md5() war noch hello geschuldet. Selbst, wenn die Anwendung (noch) relativ unkritisch ist, es können personenbezogene Daten übertragen werden und der Hash sollte da einfach sicher genug sein, um Bruteforce-Attacken zu erschweren.