### PR TITLE
Notices vermeiden

### DIFF
--- a/plugins/client/lib/rex_api_project_manager.php
+++ b/plugins/client/lib/rex_api_project_manager.php
@@ -9,7 +9,7 @@ class rex_api_project_manager extends rex_api_function
 
     public function execute()
     {
-        ob_end_clean();
+        rex_response::cleanOutputBuffers();
         $api_key = rex_request('api_key','string');
         $func = rex_request('func','string');
         

--- a/plugins/server/pages/project_manager.server.overview.php
+++ b/plugins/server/pages/project_manager.server.overview.php
@@ -351,7 +351,7 @@ if ($showlist) {
                 
                 $skip = false;
                 
-                if (is_array($skip_addon_versions)) {
+                if (isset($skip_addon_versions) && is_array($skip_addon_versions)) {
                   foreach ($skip_addon_versions as $skip_addon_version) {
   
                     if (strpos($addon['version_latest'], $skip_addon_version)) {


### PR DESCRIPTION
**Notice: ob_end_clean() : failed to delete buffer. No buffer to delete**
Bei entsprechendem Reporting-Level wirft REDAXO ein Whoops und es können keine Daten abgerufen werden.
Die Nutzung der REDAXO-Methode behebt das Problem. Sie prüft, ob es Daten im Buffer gibt, bevor versucht wird ihn zu löschen.

**Notice: Undefined variable: skip_addon_versions**
Die Variable ist nicht immer definiert.