### PR TITLE
Weitere absehbare PHP-Versionen hinzugefügt

### DIFF
--- a/plugins/server/pages/project_manager.server.config.php
+++ b/plugins/server/pages/project_manager.server.config.php
@@ -43,6 +43,8 @@ $select->addOption('8.0', '8.0');
 $select->addOption('8.1', '8.1');
 $select->addOption('8.2', '8.2');
 $select->addOption('8.3', '8.3');
+$select->addOption('8.4', '8.4');
+$select->addOption('8.5', '8.5');
 $select->setSelected($this->getConfig('php_min'));
 $n['field'] = $select->get();
 $formElements[] = $n;


### PR DESCRIPTION
https://php.watch/versions/8.5/releases
PHP 8.5 General Availability (GA)
2025-11-20

PHP 8.4 General Availability (GA)
2024-11-21